### PR TITLE
Use ismutable(::Type{<:T}) instead of ismutable(::Type{T})

### DIFF
--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -13,23 +13,23 @@ https://github.com/JuliaDiffEq/RecursiveArrayTools.jl/issues/19.
 Base.@pure ismutable(x::DataType) = x.mutable
 ismutable(x) = ismutable(typeof(x))
 
-ismutable(::Type{Array}) = true
+ismutable(::Type{<:Array}) = true
 ismutable(::Type{<:Number}) = false
 
 
 function __init__()
 
   @require StaticArrays="90137ffa-7385-5640-81b9-e52037218182" begin
-    ismutable(::Type{StaticArrays.StaticArray}) = false
-    ismutable(::Type{StaticArrays.MArray}) = true
+    ismutable(::Type{<:StaticArrays.StaticArray}) = false
+    ismutable(::Type{<:StaticArrays.MArray}) = true
   end
 
   @require LabelledArrays="2ee39098-c373-598a-b85f-a56591580800" begin
-    ismutable(::Type{LabelledArrays.LArray{T,N,Syms}}) where {T,N,Syms} = ismutable(T)
+    ismutable(::Type{<:LabelledArrays.LArray{T,N,Syms}}) where {T,N,Syms} = ismutable(T)
   end
   
   @require Flux="587475ba-b771-5e3f-ad9e-33799f191a9c" begin
-    ismutable(x::Flux.Tracker.TrackedArray) = false
+    ismutable(::Type{<:Flux.Tracker.TrackedArray}) = false
   end
 end
 


### PR DESCRIPTION
I think this is the right way to do it?

Before

```
julia> @which ArrayInterface.ismutable(typeof(SVector(0)))
ismutable(x::DataType) in ArrayInterface at /home/takafumi/.julia/dev/ArrayInterface/src/ArrayInterface.jl:13

julia> @which ArrayInterface.ismutable(typeof(MVector(0)))
ismutable(x::DataType) in ArrayInterface at /home/takafumi/.julia/dev/ArrayInterface/src/ArrayInterface.jl:13
```

After:

```
julia> @which ArrayInterface.ismutable(typeof(SVector(0)))
ismutable(::Type{#s15} where #s15<:StaticArray) in ArrayInterface at /home/takafumi/.julia/dev/ArrayInterface/src/ArrayInterface.jl:23

julia> @which ArrayInterface.ismutable(typeof(MVector(0)))
ismutable(::Type{#s14} where #s14<:MArray) in ArrayInterface at /home/takafumi/.julia/dev/ArrayInterface/src/ArrayInterface.jl:24
```

It looks like `ismutable` was returning correct answers because `SArray` is an immutable struct and `MArray` is a mutable struct.
