### PR TITLE
Add findstructralnz(A,col_index) for CSC and BBB matrix

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ArrayInterface"
 uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
-version = "1.2.1"
+version = "1.3.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ArrayInterface"
 uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
-version = "1.3.1"
+version = "1.3.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -96,6 +96,18 @@ has_sparsestruct(x::Type{<:Tridiagonal}) = true
 has_sparsestruct(x::Type{<:SymTridiagonal}) = true
 
 """
+    fast_column_indexing(x::AbstractArray)
+
+determine whether indexing along columns is fast, if it is `true`
+`findstructralnz(x,col_index)` is used, otherwise `findstructralnz(x)`
+is used.
+"""
+fast_column_indexing(x) = false
+fast_column_indexing(x::AbstractArray) = fast_column_indexing(typeof(x))
+fast_column_indexing(x::Type{<:AbstractArray}) = false
+fast_column_indexing(x::Type{<:SparseMatrixCSC}) = true
+
+"""
     findstructralnz(x::AbstractArray)
 
 Return: (I,J) #indexable objects
@@ -495,6 +507,7 @@ function __init__()
       BandedBlockBandedMatrixRowIterator(col_index_local,J,blockcolrange,cumulsizes,Ref(x))
     end
 
+    fast_column_indexing(x::Type{<:BlockBandedMatrices.BandedBlockBandedMatrix}) = true
     has_sparsestruct(::Type{<:BlockBandedMatrices.BlockBandedMatrix}) = true
     has_sparsestruct(::Type{<:BlockBandedMatrices.BandedBlockBandedMatrix}) = true
     is_structured(::Type{<:BlockBandedMatrices.BlockBandedMatrix}) = true

--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -105,6 +105,7 @@ is used.
 fast_column_indexing(x) = false
 fast_column_indexing(x::AbstractArray) = fast_column_indexing(typeof(x))
 fast_column_indexing(x::Type{<:AbstractArray}) = false
+fast_column_indexing(x::Type{<:Array}) = true
 fast_column_indexing(x::Type{<:SparseMatrixCSC}) = true
 
 """

--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -470,7 +470,7 @@ function __init__()
     end
 
     function Base.iterate(iter::BandedBlockBandedMatrixRowIterator,state::BandedBlockBandedMatrixRowState)
-      if state.row_index_local<lastindex(state.colrange)
+      if state.row_index_local<state.colrange[end]
         state.row_index_local+=1
         return (state.row_index_local+state.blockheight,state)
       elseif state.nblockrow<lastindex(iter.blockcolrange)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -65,14 +65,26 @@ rowind,colind=findstructralnz(BB)
     1,1,1,1,1]
 
 dense=collect(Ones(8,8))
-for i in 1:8
+for i in 1:7
     dense[:,i].=[1,2,3,4,5,6,7,8]
 end
 BBB=BandedBlockBandedMatrix(dense, ([4, 4] ,[4, 4]), (1, 1), (1, 1))
 rowind,colind=findstructralnz(BBB)
 @test [BBB[rowind[i],colind[i]] for i in 1:length(rowind)]==
     [1,2,3,1,2,3,4,2,3,4,5,6,7,5,6,7,8,6,7,8,
-     1,2,3,1,2,3,4,2,3,4,5,6,7,5,6,7,8,6,7,8]
+     1,2,1,1,2,3,1,2,3,4,5,6,1,5,6,7,1,6,7,8]
+
+function _nzrows(A,colind)
+    rows=Array{Int,1}()
+    for i in findstructralnz(BBB,colind)
+        push!(rows,i)
+    end
+    rows
+end
+
+@test _nzrows(BBB,3)==[2,3,4,6,7,8]
+@test _nzrows(BBB,8)==[3,4,7,8]
+
 
 @testset "setindex" begin
     @testset "$(typeof(x))" for x in [


### PR DESCRIPTION
Indexing over BandedBlockBandedMatrix in colored jacobian (https://github.com/JuliaDiffEq/DiffEqDiffTools.jl/issues/67) is much slower than CSC matrix (2.5ms vs 120ms). I changed it into a column based iteration according to https://github.com/JuliaDiffEq/DifferentialEquations.jl/issues/483 . The evaluation time of colored jacobian for BBB matrix is reduced to 87ms.