### PR TITLE
Mark AbstractQ and LQPackedQ as non-fast_scalar_indexing

### DIFF
--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -50,6 +50,8 @@ Query whether an array type has fast scalar indexing
 """
 fast_scalar_indexing(x) = true
 fast_scalar_indexing(x::AbstractArray) = fast_scalar_indexing(typeof(x))
+fast_scalar_indexing(::Type{<:LinearAlgebra.AbstractQ}) = false
+fast_scalar_indexing(::Type{<:LinearAlgebra.LQPackedQ}) = false
 
 """
     allowed_getindex(x,i...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using ArrayInterface, Test
 using Base: setindex
-import ArrayInterface: has_sparsestruct, findstructralnz
+import ArrayInterface: has_sparsestruct, findstructralnz, fast_scalar_indexing
 @test ArrayInterface.ismutable(rand(3))
 
 using StaticArrays
@@ -38,6 +38,10 @@ Sp=sparse([1,2,3],[1,2,3],[1,2,3])
 @test has_sparsestruct(Sp)
 rowind,colind=findstructralnz(Sp)
 @test [Tri[rowind[i],colind[i]] for i in 1:length(rowind)]==[1,2,3]
+
+@test !fast_scalar_indexing(qr(rand(10, 10)).Q)
+@test !fast_scalar_indexing(qr(rand(10, 10), Val(true)).Q)
+@test !fast_scalar_indexing(lq(rand(10, 10)).Q)
 
 using BandedMatrices
 


### PR DESCRIPTION
Their `getindex` are defined in terms of multiplications.  So I guess it makes sense to mark them as non-`fast_scalar_indexing`?

```julia
function getindex(Q::AbstractQ, i::Integer, j::Integer)
    x = zeros(eltype(Q), size(Q, 1))
    x[i] = 1
    y = zeros(eltype(Q), size(Q, 2))
    y[j] = 1
    return dot(x, lmul!(Q, y))
end
```

--- https://github.com/JuliaLang/julia/blob/6eebbbe2d205f8116330a77ca5e15f4a356232db/stdlib/LinearAlgebra/src/qr.jl#L526-L532


```julia
getindex(A::LQPackedQ, i::Integer, j::Integer) =
    lmul!(A, setindex!(zeros(eltype(A), size(A, 2)), 1, j))[i]
```

--- https://github.com/JuliaLang/julia/blob/6eebbbe2d205f8116330a77ca5e15f4a356232db/stdlib/LinearAlgebra/src/lq.jl#L139-L140
