### PR TITLE
Default to ismutable(array) = true

### DIFF
--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -12,12 +12,9 @@ function ismutable end
 Query whether a type is mutable or not, see
 https://github.com/JuliaDiffEq/RecursiveArrayTools.jl/issues/19.
 """
-Base.@pure ismutable(x::DataType) = x.mutable
 ismutable(x) = ismutable(typeof(x))
 
-ismutable(::Type{<:Array}) = true
-ismutable(::Type{<:SparseMatrixCSC}) = true
-ismutable(::Type{<:SparseVector}) = true
+ismutable(::Type{<:AbstractArray}) = true
 ismutable(::Type{<:Number}) = false
 
 # Piracy


### PR DESCRIPTION
I propose to get rid of the default `ismutable(x::DataType) = x.mutable`.  An array type implemented with immutable struct does not mean the array is immutable (e.g., sparse arrays #27).  Like wise, it is imaginable to implement semantically immutable array using mutable struct.

So, I think it would be nice to have a sane and predictable default.  Here, I suggest to treat arrays as mutable by default.  This way, missing definition of `ismutable` is an error, rather than a slow or incorrect computation.