### PR TITLE
Add appropriate interface for ranges

### DIFF
--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -16,6 +16,7 @@ ismutable(x) = ismutable(typeof(x))
 
 ismutable(::Type{<:AbstractArray}) = true
 ismutable(::Type{<:Number}) = false
+ismutable(::Type{<:AbstractRange}) = false
 
 # Piracy
 function Base.setindex(x::AbstractArray,v,i...)
@@ -41,6 +42,7 @@ Query whether a type can use `setindex!`
 """
 can_setindex(x) = true
 can_setindex(x::AbstractArray) = can_setindex(typeof(x))
+can_setindex(::Type{<:AbstractRange}) = false
 
 """
     fast_scalar_indexing(x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,7 @@ import ArrayInterface: has_sparsestruct, findstructralnz, fast_scalar_indexing
 using StaticArrays
 @test ArrayInterface.ismutable(@SVector [1,2,3]) == false
 @test ArrayInterface.ismutable(@MVector [1,2,3]) == true
+@test ArrayInterface.ismutable(1:10) == false
 
 using LinearAlgebra, SparseArrays
 


### PR DESCRIPTION
Only changes are to `ismutable` and `can_setindex` for `AbstractRange` types.